### PR TITLE
found some hard-coded set numbers & max card counts

### DIFF
--- a/resources/views/collection/index.blade.php
+++ b/resources/views/collection/index.blade.php
@@ -9,9 +9,9 @@
                 <div class='filters'>
                     <!-- Collected filters -->
                     <div class='button-group' data-filter-group="owned">
-                        <button data-filter="" type="button" class="btn btn-default selected js-default-filter btn-xs js-filter">All (216)</button>
+                        <button data-filter="" type="button" class="btn btn-default selected js-default-filter btn-xs js-filter">All (367)</button>
                         <button data-filter=".card.collected" type="button" class="btn btn-default btn-xs js-filter">Collected (<span class='js-collected-count'>{{ $collected->count() }}</span>)</button>
-                        <button data-filter=".card.not-collected" type="button" class="btn btn-default btn-xs js-filter">Not Collected (<span class='js-not-collected-count'>{{ 216 - $collected->count() }}</span>)</button>
+                        <button data-filter=".card.not-collected" type="button" class="btn btn-default btn-xs js-filter">Not Collected (<span class='js-not-collected-count'>{{ 367 - $collected->count() }}</span>)</button>
                     </div>
                     <!-- Type Filters -->
                     @include('shared.filters.elements')
@@ -60,7 +60,7 @@
                                 <div class='card-count'>@if (!empty($collected[$card->id])) {{$collected[$card->id]->count}} @else 0 @endif</div>
                                 <div title='Mark foil' class='js-foil-toggle foil-card'>@if (!empty($collected[$card->id]) && $collected[$card->id]->foil) F @else NF @endif</div>
                             </div>
-                            <div class='card-number'>1-{{ str_pad($card->card_number, 3, 0, STR_PAD_LEFT) }}-{{$card->rarity}}</div>
+                            <div class='card-number'>{{$card->set_number}}-{{ str_pad($card->card_number, 3, 0, STR_PAD_LEFT) }}-{{$card->rarity}}</div>
                         </div>
                     @empty
                         <p>No cards in the database, uhoh :\</p>

--- a/resources/views/decks/add.blade.php
+++ b/resources/views/decks/add.blade.php
@@ -129,7 +129,7 @@
                                         </div>
                                         <div class='card-count'>@if ($deck->cards->contains('id', $card->id)) {{ $selected_cards[$card->id]->pivot->count }} @else 0 @endif</div>
                                     </div>
-                                    <div class='card-number'>1-{{ str_pad($card->card_number, 3, 0, STR_PAD_LEFT) }}-{{$card->rarity}}</div>
+                                    <div class='card-number'>{{$card->set_number}}-{{ str_pad($card->card_number, 3, 0, STR_PAD_LEFT) }}-{{$card->rarity}}</div>
                                 </div>
 
                                 @section('scripts')

--- a/resources/views/decks/newview.blade.php
+++ b/resources/views/decks/newview.blade.php
@@ -105,7 +105,7 @@
                                         </a>
                                         <div class='card-count'>{{ $card->count }}</div>
                                     </div>
-                                    <div class='card-number'>1-{{ str_pad($card->card_number, 3, 0, STR_PAD_LEFT) }}-{{$card->rarity}}</div>
+                                    <div class='card-number'>{{$card->set_number}}-{{ str_pad($card->card_number, 3, 0, STR_PAD_LEFT) }}-{{$card->rarity}}</div>
                                 </div>
                             @empty
                                 <p>There are no cards in this deck :\</p>
@@ -198,7 +198,7 @@
                     }]);
 
                     function generateCardNumber(card) {
-                        return "[1-" + ('000' + card.card_number).substring(card.card_number.length) + "-" + card.rarity + "]";
+                        return "[" + card.set_number +"-" + ('000' + card.card_number).substring(card.card_number.length) + "-" + card.rarity + "]";
                     }
 
                     $cardlists = $('.card-list-section');

--- a/resources/views/decks/view.blade.php
+++ b/resources/views/decks/view.blade.php
@@ -105,7 +105,7 @@
                                         </a>
                                         <div class='card-count'>{{ $card->pivot->count }}</div>
                                     </div>
-                                    <div class='card-number'>1-{{ str_pad($card->card_number, 3, 0, STR_PAD_LEFT) }}-{{$card->rarity}}</div>
+                                    <div class='card-number'>{{$card->set_number}}-{{ str_pad($card->card_number, 3, 0, STR_PAD_LEFT) }}-{{$card->rarity}}</div>
                                 </div>
                             @empty
                                 <p>There are no cards in this deck :\</p>

--- a/resources/views/user/public.blade.php
+++ b/resources/views/user/public.blade.php
@@ -7,7 +7,7 @@
             <div class="panel panel-default">
                 <div class="panel-body">
                     <h1 style="margin-top: 0;">{{ $user->name }}</h1>
-                    <p>{{ $user->collected()->count() }} cards of 216 collected.</p>
+                    <p>{{ $user->collected()->count() }} cards of 367 collected.</p>
                 </div>
             </div>
         </div>

--- a/resources/views/userprofile.blade.php
+++ b/resources/views/userprofile.blade.php
@@ -7,7 +7,7 @@
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <h1>{{ $user->name }}</h1>
-                    <p>{{ $cards->count() }} cards of 216 collected.</p>
+                    <p>{{ $cards->count() }} cards of 367 collected.</p>
                 </div>
                 <div class="panel-body">
                     @if (isset($cards))
@@ -16,11 +16,11 @@
                             @forelse ($cards as $card)
                                 <div class='card collected element-{{ $card->element }}' data-card-id="{{ $card->id }}">
                                     <div class='card-image @if ($card->foil) has-foil @else no-foil @endif'>
-                                        <img class="lazy img" data-original="/img/cards/100x140/{{ $card->card_number }}.png" width="100" height="140" src=""/>
+                                        <img class="lazy img" data-original="/img/cards/100x140/{{ $card->set_number }}/{{ $card->card_number }}.png" width="100" height="140" src=""/>
                                         <div class='card-count'>{{ $card->count }}</div>
                                         <div title='Mark foil' class='foil-card'>@if ($card->foil) F @else NF @endif</div>
                                     </div>
-                                    <div class='card-number'>1-{{ str_pad($card->card_number, 3, 0, STR_PAD_LEFT) }}-{{$card->rarity}}</div>
+                                    <div class='card-number'>{{$card->set_number}}-{{ str_pad($card->card_number, 3, 0, STR_PAD_LEFT) }}-{{$card->rarity}}</div>
                                 </div>
                             @empty
                                 <p>This user hasn't collected any cards yet!</p>


### PR DESCRIPTION
I trawled through the views and found several instances where the set number was still hard-coded to 1, or the max collection count hadn't been updated to include promo & opus 2 cards.

Still can't figure out why you can't add cards in sets other than opus 1 to a deck. Even if manually insert it into the DeckCards table, it will show the overall deck count & the opus 2/pr cards in the gallery view, but won't display in the list and will remove from your deck when you next edit in the web interface.