### PR TITLE
Fix comments regex

### DIFF
--- a/app/Models/Comments/Comment.php
+++ b/app/Models/Comments/Comment.php
@@ -33,7 +33,7 @@ class Comment extends Model
         if (isset($cards[1])) {
             foreach ($cards[1] as $_c) {
                 $parts = explode('-', $_c);
-                $card = Card::find((int) $parts[1]);
+                $card = Card::where('set_number', $parts[0])->where('card_number', $parts[1])->first();
                 $c = preg_replace('/\(.+?\)\s{0,1}\[' . $card->fullCardNumber() . '\]/', $card->hoveritem(), $c);
             }
         }


### PR DESCRIPTION
This fixes #2; the issue was the original 'Find' was using the Card's "card_number" value as a way of determining the primary key value 'id', which doesn't work once you've got more than one Opus in the Cards database.

The new change will make it perform a SQL statement like 'SELECT * FROM cards WHERE 'set_number' = $parts[0] AND 'card_number' = $parts[1]', which will search using the proper columns.