### PR TITLE
Adding Site Usability Improvements

### DIFF
--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -105,8 +105,9 @@ class DeckController extends Controller
     {
         $deck = $this->fetchDeck($deck_id);
         $all_cards = Card::all();
+	$collected = Auth::user()->collection->keyBy('card_id');
         $selected_cards = $deck->cards->keyBy('id');
-        return view('decks.add', ['deck' => $deck, 'allcards' => $all_cards, 'selected_cards' => $selected_cards]);
+        return view('decks.add', ['deck' => $deck, 'allcards' => $all_cards, 'selected_cards' => $selected_cards, 'collected' => $collected]);
     }
 
     public function processDelete(Request $request, $deck_id)

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -136,6 +136,21 @@ $(document).ready(function() {
         // combine filters
         var filterValue = concatValues( filters );
         $grid.isotope({ filter: filterValue });
+        console.log(filterValue);
+    });
+
+    $('.js-mine-filter').click(function() {
+        var $this = $(this);
+        if (filters['mine'] == '.collected') {
+            delete(filters['mine']);
+            $(this).removeClass('selected');
+        } else {
+            filters['mine'] = '.collected';
+            $(this).addClass('selected');
+        }
+        var filterValue = concatValues( filters );
+        $grid.isotope({ filter: filterValue });
+        console.log(filterValue);
     });
 
     $('.js-name-filter').keyup(function() {

--- a/resources/views/decks/add.blade.php
+++ b/resources/views/decks/add.blade.php
@@ -136,7 +136,7 @@
                                 @section('scripts')
                                 <script id="js-template" type="text/plain">
                                     <input class="js-card-%card_id%" type="hidden" name="card[%card_id%]" value="%count%"/>
-                                    <li class="js-card-%card_id%">
+                                    <li class="js-card-%card_id% img-instead">
                                         <img src="/img/icons/%element%.png"/>
                                         <a class='js-view-full' href="/img/cards/original/%set_number%/%card_number%.png">%title%</a> (<span>%count%</span>)
                                     </li>

--- a/resources/views/decks/add.blade.php
+++ b/resources/views/decks/add.blade.php
@@ -95,12 +95,13 @@
                     <div class="panel panel-default">
                         <div class="panel-heading deckbuilder-filters">
                             @include('shared.filters.name')
+                            @include('shared.filters.collected')
                             @include('shared.filters.elements')
                             <div class='clearfix'></div>
                         </div>
                         <div class="panel-body isotope">
                             @forelse ($allcards as $card)
-                                <div class='card element-{{ $card->element }}' data-card-id="{{ $card->id }}" data-title="{{ $card->name }}" data-type="{{ $card->type }}" data-number="{{ $card->card_number }}" data-set-number="{{ $card->set_number }}" data-element="{{ $card->element }}">
+                                <div class='card element-{{ $card->element }} @if ($collected->contains('card_id', $card->id)) collected @endif' data-card-id="{{ $card->id }}" data-title="{{ $card->name }}" data-type="{{ $card->type }}" data-number="{{ $card->card_number }}" data-set-number="{{ $card->set_number }}" data-element="{{ $card->element }}">
                                     <div class='card-image'>
                                         <img class="lazy img" data-original="/img/cards/100x140/{{ $card->set_number }}/{{ $card->card_number }}.png" width="100" height="140" src=""/>
                                         <div class='actions'>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -97,7 +97,8 @@
                                 </a>
 
                                 <ul class="dropdown-menu" role="menu">
-                                    <li><a href="{{ url('/profile') }}">Profile</a></li>
+                                    <li><a href="{{ url('/u/'. Auth::user()->username) }}">View Profile</a></li>
+                                    <li><a href="{{ url('/profile') }}">Edit Profile</a></li>
                                     <li><a href="{{ url('/messages') }}">Messages</a></li>
                                     <li>
                                         <a href="{{ url('/logout') }}"

--- a/resources/views/shared/filters/collected.blade.php
+++ b/resources/views/shared/filters/collected.blade.php
@@ -1,0 +1,5 @@
+<div id="search-filters">
+    <div id="sets-filter" class='form-group btn-group filter-toggle-select input-group pull-right'>
+        <button type="button" class="js-mine-filter btn btn-default">Collected Only<input type="checkbox" name="collected" value="1"/></button>
+    </div>
+</div>

--- a/resources/views/user/public.blade.php
+++ b/resources/views/user/public.blade.php
@@ -55,9 +55,11 @@
                             @foreach ($user->collected() as $collect)
                                 <div class='card collected element-{{ $collect->card->element }}' data-card-id="{{ $collect->card->id }}">
                                     <div class='card-image @if ($collect->foil_count > 0) has-foil @else no-foil @endif'>
-                                        <img class="lazy img" data-original="/img/cards/100x140/{{ $collect->card->set_number }}/{{ $collect->card->card_number }}.png" width="100" height="140" src=""/>
-                                        <div title='Regular' class='card-count'>{{ $collect->count }}</div>
-                                        <div title='Foil' class='foil-card'>@if ($collect->foil_count > 0) {{ $collect->foil_count }} @else 0 @endif</div>
+                                        <a class='js-view-full' href="/img/cards/original/{{ $collect->card->set_number }}/{{ $collect->card->card_number }}.png">
+                                            <img class="lazy img" data-original="/img/cards/100x140/{{ $collect->card->set_number }}/{{ $collect->card->card_number }}.png" width="100" height="140" src=""/>
+                                            <div title='Regular' class='card-count'>{{ $collect->count }}</div>
+                                            <div title='Foil' class='foil-card'>@if ($collect->foil_count > 0) {{ $collect->foil_count }} @else 0 @endif</div>
+                                        </a>
                                     </div>
                                     <div class='card-number'>{{ $collect->card->fullCardNumber() }}</div>
                                 </div>


### PR DESCRIPTION
A collection of nice-to-haves I'd collected as I used fftcgdb.com:

- The "User" menu now has the ability to view one's public profile as others on the site would see it ([example here](http://i.imgur.com/5dtry6A.png))
- The "public profile" screen now shows zoomed-in views of cards in the isotope grid when you click on them ([example here](http://i.imgur.com/GFLPvWB.png))
- The "deck building" screen now allows you to only show cards that are in your collection when editing a deck ([example here](http://i.imgur.com/MGci7ng.png))

I tried my best to reuse existing styles but UX is not my strongsuit, so please feel to request adjustments and I'll do what I can.