### PR TITLE
Fixing Collection Controller Use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM ikaruwa/lamp_base:latest
-MAINTAINER Nick Fraker <nickdontspam@gmail.com>
+LABEL name="fftcgdb"
+LABEL version="1.0.0"
+LABEL release="0"
+LABEL vendor="Nick Fraker <nickdontspam@gmail.com>"
+LABEL vcs-type="git"
+LABEL vcs-url="https://github.com/danives/fftcgdb"
+LABEL authoritative-source-url="https://hub.docker.com/r/ikaruwa/fftcgdb"
+LABEL distribution-scope="public"
 
 # Add files
 COPY . /tmp/FFTCG

--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -31,7 +31,7 @@ class CollectionController extends Controller
     {
         $cards = Card::all();
         View::share('cards', $cards);
-        $collected = Collection::where('user_id', Auth::user()->id)->get()->keyBy('card_id');
+        $collected = Auth::user()->collected()->keyBy('card_id');
         $countall = Card::get()->count();
         View::share('collected', $collected);
         return view('collection.indexalt', [ 'countall' => $countall ]);
@@ -39,7 +39,7 @@ class CollectionController extends Controller
 
     public function profile()
     {
-        $collected = Auth::user()->collection->keyBy('card_id');
+        $collected = Auth::user()->collected()->keyBy('card_id');
         $countall = Card::get()->count();
         return view('collection.profile', [ 'cards' => Card::all(), 'collected' => $collected, 'countall' => $countall ]);
     }
@@ -47,7 +47,7 @@ class CollectionController extends Controller
     public function update(Request $request)
     {
         $user_id = Auth::user()->id;
-        $existing = Collection::where('user_id', $user_id)->get();
+        $existing = Auth::user()->collection->keyBy('card_id');
         $cards = $request->input('card');
         foreach ($cards as $card_id => $c) {
             $e = $existing->filter(function ($item) use ($card_id) {
@@ -68,8 +68,11 @@ class CollectionController extends Controller
             // Wanted
             $e->wanted = (empty($c['wanted'])) ? 0 : $c['wanted'];
             $e->foil_wanted = (empty($c['foil_wanted'])) ? 0 : $c['foil_wanted'];
-
-            $e->save();
+            if (($e->count == 0) && ($e->foil_count == 0) && ($e->trade_count == 0) && ($e->foil_trade_count == 0) && ($e->wanted == 0) && ($e->foil_wanted == 0)) {
+                $e->forceDelete();
+            } else {
+                $e->save();
+            }
         }
 
         if (!$request->ajax()) {

--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -105,7 +105,7 @@ class DeckController extends Controller
     {
         $deck = $this->fetchDeck($deck_id);
         $all_cards = Card::all();
-	    $collected = Auth::user()->collection->keyBy('card_id');
+        $collected = Auth::user()->collected()->keyBy('card_id');
         $selected_cards = $deck->cards->keyBy('id');
         return view('decks.add', ['deck' => $deck, 'allcards' => $all_cards, 'selected_cards' => $selected_cards, 'collected' => $collected]);
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -62,10 +62,11 @@ class UserController extends Controller
         }
 
         $countall = Card::get()->count();
+        $collection = $user->collection();
         $decks = Deck::where('user_id', $user->id)
                         ->where('public', true)
                         ->orderBy('created_at', 'DESC')->get();
 
-        return view('user.public', ['user' => $user, 'public_decks' => $decks, 'public_deck_title' => 'Users Public Decks', 'countall' => $countall]);
+        return view('user.public', ['user' => $user, 'collection' => $collection, 'public_decks' => $decks, 'public_deck_title' => 'Users Public Decks', 'countall' => $countall]);
     }
 }

--- a/resources/views/collection/index.blade.php
+++ b/resources/views/collection/index.blade.php
@@ -11,7 +11,7 @@
                     <div class='button-group' data-filter-group="owned">
                         <button data-filter="" type="button" class="btn btn-default selected js-default-filter btn-xs js-filter">All ({{ $countall }})</button>
                         <button data-filter=".card.collected" type="button" class="btn btn-default btn-xs js-filter">Collected (<span class='js-collected-count'>{{ $collected->count() }}</span>)</button>
-                        <button data-filter=".card.not-collected" type="button" class="btn btn-default btn-xs js-filter">Not Collected (<span class='js-not-collected-count'>{{ $countall - $collected->count() }}</span>)</button>
+                        <button data-filter=".card.not-collected" type="button" class="btn btn-default btn-xs js-filter">Not Collected (<span class='js-not-collected-count'>{{ $countall - $collected()->count() }}</span>)</button>
                     </div>
                     <!-- Type Filters -->
                     @include('shared.filters.elements')

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -168,7 +168,7 @@
                             <div class="input-group">
                                 <div class='btn-group filter-toggle-select'>
                                     <button type="button" class="btn btn-default btn-sm">
-                                        Opus 1
+                                        Opus I
                                         <input type="checkbox" name="sets[]" value="1"/>
                                     </button>
                                     <button type="button" class="btn btn-default btn-sm">


### PR DESCRIPTION
- Correcting uses of `collection` vs `collected()`
- Removing empty records from collections table to protect against duplicate card entries and thin out unnecessary records in collections table for faster query response.
- Updating container labels to use community suggested scheme
- Fixing typo in search filter (1 instead of I)